### PR TITLE
Add sign-in subtitle to login screen

### DIFF
--- a/app/views/login.ejs
+++ b/app/views/login.ejs
@@ -30,6 +30,7 @@
 									<div class="nk-block-head">
 										<div class="nk-block-head-content">
 											<h4 class="nk-block-title">Document Controller</h4>
+											<p class="nk-block-des mt-1">Sign in to your account</p>
 										</div>
 									</div>
 									<form id="loginForm" class="form-validate is-alter">


### PR DESCRIPTION
## Summary
- Added a "Sign in to your account" subtitle below the "Document Controller" title on the login page for better UX

## Test plan
- [ ] Visit the login page and verify the subtitle appears below the title
- [ ] Confirm no layout issues on different screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)